### PR TITLE
assembly and project name update

### DIFF
--- a/Orleans.TelemetryConsumers.ElasticSearch.sln
+++ b/Orleans.TelemetryConsumers.ElasticSearch.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElasticSearchTelemetryConsumer", "src\ElasticSearchTelemetryConsumer\ElasticSearchTelemetryConsumer.csproj", "{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orleans.TelemetryConsumers.ElasticSearch", "src\ElasticSearchTelemetryConsumer\Orleans.TelemetryConsumers.ElasticSearch.csproj", "{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHost", "test\TestHost\TestHost.csproj", "{198CABB3-0ABF-47CB-8D7A-2D7D7AE69A2D}"
 EndProject

--- a/src/ElasticSearchTelemetryConsumer/Orleans.TelemetryConsumers.ElasticSearch.csproj
+++ b/src/ElasticSearchTelemetryConsumer/Orleans.TelemetryConsumers.ElasticSearch.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{8A54E4AA-5C5E-479D-9DEB-C56A8FBB4E25}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SBTech.Orleans.ElasticUtils</RootNamespace>
-    <AssemblyName>OrleansElasticUtils</AssemblyName>
+    <RootNamespace>Orleans.TelemetryConsumers.ElasticSearch</RootNamespace>
+    <AssemblyName>Orleans.TelemetryConsumers.ElasticSearch</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/test/TestHost/TestHost.csproj
+++ b/test/TestHost/TestHost.csproj
@@ -114,9 +114,9 @@
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\ElasticSearchTelemetryConsumer\ElasticSearchTelemetryConsumer.csproj">
+    <ProjectReference Include="..\..\src\ElasticSearchTelemetryConsumer\Orleans.TelemetryConsumers.ElasticSearch.csproj">
       <Project>{8a54e4aa-5c5e-479d-9deb-c56a8fbb4e25}</Project>
-      <Name>ElasticSearchTelemetryConsumer</Name>
+      <Name>Orleans.TelemetryConsumers.ElasticSearch</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
The projectname and the assembly name should match the nuspec for appveyor nuget pack to happen